### PR TITLE
Get, build, & use libfaketime 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     python-support \
     python-twisted \
     supervisor \
+    unzip \
     wget
 
 RUN pip install \
@@ -28,6 +29,15 @@ RUN pip install \
     whisper
 RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/lib" carbon
 RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/webapp" graphite-web
+
+# libfaketime (allows falsifying system date & time)
+# THIS IS JUST A PROOF-OF-CONCEPT. Doesn't support externally specifying the date/time yet.
+RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip ;\
+    unzip master.zip ;\
+    cd libfaketime-master && make install && cd ..
+RUN export LD_PRELOAD=/usr/local/lib/faketime/libfaketime.so.1 ;\
+    export FAKETIME_NO_CACHE=1 ;\
+    export FAKETIME="2017-08-24 00:00:00"
 
 # Grafana
 RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.4.1_amd64.deb ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,12 @@ RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="
 
 # libfaketime (allows falsifying system date & time)
 # THIS IS JUST A PROOF-OF-CONCEPT. Doesn't support externally specifying the date/time yet.
-RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip ;\
-    unzip master.zip ;\
+RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip
+    unzip master.zip
     cd libfaketime-master && make install && cd ..
-ENV LD_PRELOAD /usr/local/lib/faketime/libfaketime.so.1
 ENV FAKETIME_NO_CACHE 1
-ENV FAKETIME "2017-08-24 00:00:00"
+ENV FAKETIME 2017-08-24 00:00:00
+ENV LD_PRELOAD /usr/local/lib/faketime/libfaketime.so.1
 
 # Grafana
 RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.4.1_amd64.deb ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,14 @@ RUN pip install \
 RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/lib" carbon
 RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/webapp" graphite-web
 
-# libfaketime (allows falsifying system date & time)
-# THIS IS JUST A PROOF-OF-CONCEPT. Doesn't support externally specifying the date/time yet.
+# libfaketime - allows falsifying system date & time
+#   To use this, the following env vars must be set with   docker run -e var=val
+#       FAKETIME_NO_CACHE=1
+#       FAKETIME="YYYY-MM-DD HH:MM:SS"     (also supports relative offsets from "now". E.g. "-14d", "-6h")
+#       LD_PRELOAD=/usr/local/lib/faketime/libfaketime.so.1
 RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip ;\
     unzip master.zip ;\
     cd libfaketime-master && make install && cd ..
-ENV FAKETIME_NO_CACHE 1
-ENV FAKETIME 2017-08-24 00:00:00
-ENV LD_PRELOAD /usr/local/lib/faketime/libfaketime.so.1
 
 # Grafana
 RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.4.1_amd64.deb ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="
 
 # libfaketime (allows falsifying system date & time)
 # THIS IS JUST A PROOF-OF-CONCEPT. Doesn't support externally specifying the date/time yet.
-RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip
-    unzip master.zip
+RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip ;\
+    unzip master.zip ;\
     cd libfaketime-master && make install && cd ..
 ENV FAKETIME_NO_CACHE 1
 ENV FAKETIME 2017-08-24 00:00:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN pip install --install-option="--prefix=/var/lib/graphite" --install-option="
 RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaketime/archive/master.zip ;\
     unzip master.zip ;\
     cd libfaketime-master && make install && cd ..
-RUN export LD_PRELOAD=/usr/local/lib/faketime/libfaketime.so.1 ;\
-    export FAKETIME_NO_CACHE=1 ;\
-    export FAKETIME="2017-08-24 00:00:00"
+ENV LD_PRELOAD /usr/local/lib/faketime/libfaketime.so.1
+ENV FAKETIME_NO_CACHE 1
+ENV FAKETIME "2017-08-24 00:00:00"
 
 # Grafana
 RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.4.1_amd64.deb ;\


### PR DESCRIPTION
The libfaketime library is built and pre-loaded to permit spoofing the current time. It reads the FAKETIME environment variable to find the date & time (YYYY-MM-DD hh:mm:ss), or a relative offset ([+-]\d+[mhdy]) from the actual current time. 

The faked time is supplied to all processes when they make a system call that has been overridden / hooked by this pre-loaded library. See the readme for the library for more time options and platform compatibility.
https://github.com/wolfcw/libfaketime