### PR TITLE
Grafana 4.6.2 + fix graphite admin login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     python-simplejson \
     python-support \
     python-twisted \
+    sqlite3 \
     supervisor \
     unzip \
     wget
@@ -40,15 +41,15 @@ RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaket
     cd libfaketime-master && make install && cd ..
 
 # Grafana
-RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.4.1_amd64.deb ;\
-    dpkg -i grafana_4.4.1_amd64.deb ;\
-    rm grafana_4.4.1_amd64.deb
+RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.6.2_amd64.deb ;\
+    dpkg -i grafana_4.6.2_amd64.deb ;\
+    rm grafana_4.6.2_amd64.deb
 
 # Add graphite webapp config
 ADD ./initial_data.json /var/lib/graphite/webapp/graphite/initial_data.json
 ADD ./local_settings.py /var/lib/graphite/webapp/graphite/local_settings.py
-RUN PYTHONPATH=/var/lib/graphite/webapp django-admin migrate --settings=graphite.settings --run-syncdb
-
+RUN cd /var/lib/graphite/webapp && PYTHONPATH=/var/lib/graphite/webapp django-admin migrate  --settings=graphite.settings --no-input --run-syncdb
+RUN cd /var/lib/graphite/webapp && PYTHONPATH=/var/lib/graphite/webapp django-admin loaddata --settings=graphite.settings /var/lib/graphite/webapp/graphite/initial_data.json
 
 # Add system service config
 ADD ./nginx.conf /etc/nginx/nginx.conf

--- a/initial_data.json
+++ b/initial_data.json
@@ -12,7 +12,7 @@
       "last_login": "2011-09-20 17:02:14",
       "groups": [],
       "user_permissions": [],
-      "password": "sha1$1b11b$edeb0a67a9622f1f2cfeabf9188a711f5ac7d236",
+      "password": "pbkdf2_sha256$24000$xVrRiObAhDn2$QdL2scUhlJ0Fde53JNc/5xzbjS2eBH441ZoFY4ovOE0=",
       "email": "root@example.com",
       "date_joined": "2011-09-20 17:02:14"
     }

--- a/local_settings.py
+++ b/local_settings.py
@@ -40,3 +40,5 @@ TIME_ZONE = 'UTC'
 #DATABASE_PASSWORD = 'graphite-is-awesome'
 #DATABASE_HOST = 'mysql.mycompany.com'
 #DATABASE_PORT = '3306'
+
+SECRET_KEY = 'mydummysecret'

--- a/nginx.conf
+++ b/nginx.conf
@@ -62,8 +62,8 @@ http {
       alias /var/lib/graphite/webapp/content;
     }
 
-    location /media {
-      alias /usr/share/pyshared/django/contrib/admin/media;
+    location /static/admin {
+      alias /usr/lib/python2.7/dist-packages/django/contrib/admin/static/admin;
     }
   }
 }


### PR DESCRIPTION
changes tested locally.

graphite admin login works again and admin sites now find the static resources.

sqlite3 is added so that the `django-admin dbshell  --settings=graphite.settings` command can be used.