### PR TITLE
Upgrade Grafana to 4.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaket
     cd libfaketime-master && make install && cd ..
 
 # Grafana
-RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.6.2_amd64.deb ;\
-    dpkg -i grafana_4.6.2_amd64.deb ;\
-    rm grafana_4.6.2_amd64.deb
+RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.6.3_amd64.deb ;\
+    dpkg -i grafana_4.6.3_amd64.deb ;\
+    rm grafana_4.6.3_amd64.deb
 
 # Add graphite webapp config
 ADD ./initial_data.json /var/lib/graphite/webapp/graphite/initial_data.json


### PR DESCRIPTION
changes tested locally.

on a clean re-build this will also use newer versions of graphite/carbone/whisper:
(building the docker image with "--no-cache" options or on a machine that never build that image,
causing all the statements to be executed once more, so that we fetch the latest versions from pypi)
```
root@5aa6de7c1a1d:/# ll /var/lib/graphite/lib
total 28
drwxr-xr-x  8 root root 4096 Feb 15 10:01 ./
drwxr-xr-x 25 root root 4096 Feb 15 10:01 ../
drwxr-xr-x  3 root root 4096 Feb 15 09:55 carbon/
drwxr-xr-x  2 root root 4096 Feb 15 09:55 carbon-1.1.2-py2.7.egg-info/
drwxr-xr-x  4 root root 4096 Feb 15 10:01 twisted/
drwxr-xr-x  2 root root 4096 Feb 15 09:55 txAMQP-0.8.2-py2.7.egg-info/
drwxr-xr-x  4 root root 4096 Feb 15 09:55 txamqp/
root@5aa6de7c1a1d:/# ll /var/lib/graphite/webapp
total 696
drwxr-xr-x 15 root root   4096 Feb 15 09:56 ./
drwxr-xr-x 25 root root   4096 Feb 15 10:01 ../
-rwxr-xr-x  1 root root 549223 Feb 15 09:55 _cffi_backend.so*
-rwxr-xr-x  1 root root  62224 Feb 15 09:55 _scandir.so*
drwxr-xr-x  2 root root   4096 Feb 15 09:55 cairocffi/
drwxr-xr-x  2 root root   4096 Feb 15 09:55 cairocffi-0.8.0-py2.7.egg-info/
drwxr-xr-x  2 root root   4096 Feb 15 09:55 cffi/
drwxr-xr-x  2 root root   4096 Feb 15 09:55 cffi-1.11.4-py2.7.egg-info/
drwxr-xr-x  6 root root   4096 Feb 15 09:55 content/
drwxr-xr-x 18 root root   4096 Feb 15 09:56 graphite/
drwxr-xr-x  2 root root   4096 Feb 15 09:55 graphite_web-1.1.2-py2.7.egg-info/
drwxr-xr-x  3 root root   4096 Feb 15 09:55 pycparser/
drwxr-xr-x  2 root root   4096 Feb 15 09:55 pycparser-2.18-py2.7.egg-info/
drwxr-xr-x  2 root root   4096 Feb 15 09:55 scandir-1.7-py2.7.egg-info/
-rw-r--r--  1 root root  24116 Feb 15 09:55 scandir.py
-rw-r--r--  1 root root  18231 Feb 15 09:55 scandir.pyc
```

this also allows to use the new graphite query format (assuming a properly configured data source)
see here http://graphite.readthedocs.io/en/latest/releases/1_1_1.html
`aliasByNode(movingAverage(sortByName(test.*),"5min"),1)` can be written as `test.*|sortByName()|movingAverage("5min")|aliasByNode(1)`.
