### PR TITLE
Upgrade Grafana to 5.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ RUN wget --no-check-certificate -O master.zip https://github.com/wolfcw/libfaket
     cd libfaketime-master && make install && cd ..
 
 # Grafana
-RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.6.3_amd64.deb ;\
-    dpkg -i grafana_4.6.3_amd64.deb ;\
-    rm grafana_4.6.3_amd64.deb
+RUN wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.1.4_amd64.deb ;\
+    dpkg -i grafana_5.1.4_amd64.deb ;\
+    rm grafana_5.1.4_amd64.deb
 
 # Add graphite webapp config
 ADD ./initial_data.json /var/lib/graphite/webapp/graphite/initial_data.json

--- a/grafana-defaults.ini
+++ b/grafana-defaults.ini
@@ -135,6 +135,9 @@ auto_assign_org = true
 # Default role new users will be automatically assigned (if disabled above is set to true)
 auto_assign_org_role = Viewer
 
+# Default UI theme ("dark" or "light")
+default_theme = dark
+
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access


### PR DESCRIPTION
ini adjustment was necessary, otherwise the new css files were not found.

we should probably at some point re-use the latest defaults and only adjust the values we actually need for the image.

see history and diffs between tags of:
https://github.com/grafana/grafana/blob/master/conf/defaults.ini