### PR TITLE
Disable graphite tags

### DIFF
--- a/carbon.conf
+++ b/carbon.conf
@@ -204,6 +204,9 @@ WHISPER_FALLOCATE_CREATE = True
 # Example: store everything
 # BIND_PATTERNS = #
 
+# Tag support, when enabled carbon will make HTTP calls to graphite-web to update the tag index
+ENABLE_TAGS = False
+
 # To configure special settings for the carbon-cache instance 'b', uncomment this:
 #[cache:b]
 #LINE_RECEIVER_PORT = 2103


### PR DESCRIPTION
Updates carbon.conf such that graphite tags are disabled by
setting `ENABLE_TAGS = False`.

Support for tags was added in 1.1.0 and allows tags to be added
to a series by appending them to the series name when passing
it to carbon: https://graphite.readthedocs.io/en/latest/tags.html

Whether tags are used or not, carbon will automatically make a
request to graphite-web for every series. Graphite web then
adds each series name to a default tag called `name`. If a large
number of metrics are created at the same time this can put
considerable load on graphite-web, particularly if it is running
with a single gunicorn worker and an SQLite backend.

See:

 - https://github.com/graphite-project/carbon/blob/a87b9c2d757bb36da9094c188ff3d913577021fe/lib/carbon/writer.py#L143-L144
 - https://github.com/graphite-project/carbon/blob/a87b9c2d757bb36da9094c188ff3d913577021fe/lib/carbon/writer.py#L199-L217
 - https://github.com/graphite-project/carbon/blob/a87b9c2d757bb36da9094c188ff3d913577021fe/lib/carbon/database.py#L62-L75

While it is possible to handle this load by increasing the number
of workers and swapping out SQLite, this should not be required
in situations where tags are not being used.

See https://github.com/graphite-project/carbon/issues/816 for more
information.