### PR TITLE
Specify DJANGO_SETTINGS_MODULE in supervisord conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -21,7 +21,7 @@ autorestart = true
 [program:graphite-webapp]
 user = www-data
 directory = /var/lib/graphite/webapp
-environment = PYTHONPATH='/var/lib/graphite/webapp'
+environment = PYTHONPATH='/var/lib/graphite/webapp',DJANGO_SETTINGS_MODULE='graphite.settings'
 command = /usr/bin/gunicorn graphite.wsgi:application -b127.0.0.1:8000
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log


### PR DESCRIPTION
Fixes graphite web which has been broken (in some scenarios) since https://github.com/XN137/docker-graphite-grafana/pull/6.