### PR TITLE
Install image-renderer plugin by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN wget https://dl.grafana.com/oss/release/grafana_6.4.5_amd64.deb ;\
     dpkg -i grafana_6.4.5_amd64.deb ;\
     rm grafana_6.4.5_amd64.deb
 
+RUN grafana-cli plugins install grafana-image-renderer
+
 # Add graphite webapp config
 ADD ./initial_data.json /var/lib/graphite/webapp/graphite/initial_data.json
 ADD ./local_settings.py /var/lib/graphite/webapp/graphite/local_settings.py


### PR DESCRIPTION
This used to work out of the box in a previous version.  But it appears
that with 6.4.x, the plugin is not included anymore in Grafana.